### PR TITLE
PIDMR-128 Process of accepting new provider

### DIFF
--- a/src/AddEditProvider.tsx
+++ b/src/AddEditProvider.tsx
@@ -1,5 +1,5 @@
 import { Badge, Button, Col, Form, Row } from "react-bootstrap";
-import { FaEdit, FaPlusCircle } from "react-icons/fa";
+import { FaEdit, FaInfoCircle, FaPlusCircle } from "react-icons/fa";
 import { AuthContext } from "./auth";
 import { useContext, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -10,7 +10,7 @@ import { toast } from "react-hot-toast";
 const PIDMR_API = import.meta.env.VITE_PIDMR_API;
 const PROVIDERS_ADMIN_API_ROUTE = `${PIDMR_API}/v1/admin/providers`;
 
-function AddEditProvider({ editMode = false }: { editMode?: boolean }) {
+function AddEditProvider({ editMode = 0 }: { editMode?: number }) {
   const navigate = useNavigate();
   const params = useParams();
 
@@ -94,9 +94,9 @@ function AddEditProvider({ editMode = false }: { editMode?: boolean }) {
         });
 
         if (response.ok) {
-          navigate("/supported-pids");
+          navigate("/managed-pids");
           toast.success(
-            `Provider ${editMode ? "updated" : "added"} succesfully!`,
+            `Provider ${editMode ? "updated" : "added"} successfully!`,
           );
         } else {
           response.json().then((data) => {
@@ -136,7 +136,7 @@ function AddEditProvider({ editMode = false }: { editMode?: boolean }) {
 
   return (
     <div className="mt-4">
-      {editMode ? (
+      {editMode == 1 ? (
         <h5>
           <FaEdit className="me-2" /> Edit provider{" "}
           <Badge className="ms-2" bg="dark">
@@ -144,130 +144,146 @@ function AddEditProvider({ editMode = false }: { editMode?: boolean }) {
             id: {params.id}{" "}
           </Badge>
         </h5>
-      ) : (
+      ) : editMode == 0 ? (
         <h5>
           <FaPlusCircle className="me-2" />
           Add new Provider
         </h5>
+      ) : (
+        <h5>
+          <FaInfoCircle className="me-2" /> Provider Details{" "}
+          <Badge className="ms-2" bg="dark">
+            {" "}
+            id: {params.id}{" "}
+          </Badge>
+        </h5>
       )}
       <Form className="mt-4">
-        <Row className="mb-3">
-          <Form.Group as={Col} controlId="formProviderPidType">
-            <Form.Label>PID Type:</Form.Label>
-            <Form.Control
-              type="text"
-              placeholder="Enter PID Type"
-              onChange={(e) => setInfo({ ...info, type: e.target.value })}
-              value={info.type}
-            />
-          </Form.Group>
-
-          <Form.Group as={Col} controlId="formProviderName">
-            <Form.Label>Name:</Form.Label>
-            <Form.Control
-              type="text"
-              placeholder="Enter PID Name"
-              onChange={(e) => setInfo({ ...info, name: e.target.value })}
-              value={info.name}
-            />
-          </Form.Group>
-        </Row>
-        <Form.Group className="mb-3" controlId="formProviderDescription">
-          <Form.Label>Description:</Form.Label>
-          <Form.Control
-            as="textarea"
-            rows={2}
-            placeholder="Enter a short description"
-            onChange={(e) => setInfo({ ...info, description: e.target.value })}
-            value={info.description}
-          />
-        </Form.Group>
-        <Form.Group className="mb-3" controlId="formProviderRegexes">
-          <Form.Label>Regexes used for identification:</Form.Label>
-          {info.regexes.map((item, index) => (
-            <div className="mb-2 d-flex justify-content-between" key={index}>
+        <fieldset disabled={editMode === 2}>
+          <Row className="mb-3">
+            <Form.Group as={Col} controlId="formProviderPidType">
+              <Form.Label>PID Type:</Form.Label>
               <Form.Control
                 type="text"
-                name={`formProviderRegex_${index}`}
-                value={item}
+                placeholder="Enter PID Type"
+                onChange={(e) => setInfo({ ...info, type: e.target.value })}
+                value={info.type}
+              />
+            </Form.Group>
+
+            <Form.Group as={Col} controlId="formProviderName">
+              <Form.Label>Name:</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="Enter PID Name"
+                onChange={(e) => setInfo({ ...info, name: e.target.value })}
+                value={info.name}
+              />
+            </Form.Group>
+          </Row>
+          <Form.Group className="mb-3" controlId="formProviderDescription">
+            <Form.Label>Description:</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={2}
+              placeholder="Enter a short description"
+              onChange={(e) =>
+                setInfo({ ...info, description: e.target.value })
+              }
+              value={info.description}
+            />
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="formProviderRegexes">
+            <Form.Label>Regexes used for identification:</Form.Label>
+            {info.regexes.map((item, index) => (
+              <div className="mb-2 d-flex justify-content-between" key={index}>
+                <Form.Control
+                  type="text"
+                  name={`formProviderRegex_${index}`}
+                  value={item}
+                  onChange={(e) => {
+                    handleRegexChange(index, e.target.value);
+                  }}
+                />
+                <Button
+                  className="ms-2"
+                  size="sm"
+                  variant="outline-danger"
+                  onClick={() => {
+                    handleRegexRemove(index);
+                  }}
+                >
+                  Delete
+                </Button>
+              </div>
+            ))}
+
+            <Button
+              className="d-block"
+              variant="outline-dark"
+              size="sm"
+              onClick={handleRegexAdd}
+            >
+              Add new regex
+            </Button>
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="formProviderResolve">
+            <div className="mb-2">
+              <span>Select resolve modes that this provider supports:</span>
+            </div>
+            <div className="ms-4">
+              <Form.Check
+                inline
+                label="Landing Page"
+                name="formProviderResolve"
+                type="checkbox"
+                id="providerResolveLandingPage"
+                checked={hasResolution("landingpage")}
                 onChange={(e) => {
-                  handleRegexChange(index, e.target.value);
+                  handleCheckBoxChange("landingpage", e.target.checked);
                 }}
               />
-              <Button
-                className="ms-2"
-                size="sm"
-                variant="outline-danger"
-                onClick={() => {
-                  handleRegexRemove(index);
+              <Form.Check
+                inline
+                label="Metadata"
+                name="formProviderResolve"
+                type="checkbox"
+                id="providerResolveMetadata"
+                checked={hasResolution("metadata")}
+                onChange={(e) => {
+                  handleCheckBoxChange("metadata", e.target.checked);
                 }}
-              >
-                Delete
-              </Button>
+              />
+              <Form.Check
+                inline
+                label="Resource"
+                name="formProviderResolve"
+                type="checkbox"
+                id="providerResolveResource"
+                checked={hasResolution("resource")}
+                onChange={(e) => {
+                  handleCheckBoxChange("resource", e.target.checked);
+                }}
+              />
             </div>
-          ))}
-
-          <Button
-            className="d-block"
-            variant="outline-dark"
-            size="sm"
-            onClick={handleRegexAdd}
-          >
-            Add new regex
-          </Button>
-        </Form.Group>
-        <Form.Group className="mb-3" controlId="formProviderResolve">
-          <div className="mb-2">
-            <span>Select resolve modes that this provider supports:</span>
-          </div>
-          <div className="ms-4">
-            <Form.Check
-              inline
-              label="Landing Page"
-              name="formProviderResolve"
-              type="checkbox"
-              id="providerResolveLandingPage"
-              checked={hasResolution("landingpage")}
-              onChange={(e) => {
-                handleCheckBoxChange("landingpage", e.target.checked);
-              }}
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="formProviderExample">
+            <Form.Label>PID Example:</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Provide a valid PID as an example"
+              onChange={(e) => setInfo({ ...info, example: e.target.value })}
+              value={info.example}
             />
-            <Form.Check
-              inline
-              label="Metadata"
-              name="formProviderResolve"
-              type="checkbox"
-              id="providerResolveMetadata"
-              checked={hasResolution("metadata")}
-              onChange={(e) => {
-                handleCheckBoxChange("metadata", e.target.checked);
-              }}
-            />
-            <Form.Check
-              inline
-              label="Resource"
-              name="formProviderResolve"
-              type="checkbox"
-              id="providerResolveResource"
-              checked={hasResolution("resource")}
-              onChange={(e) => {
-                handleCheckBoxChange("resource", e.target.checked);
-              }}
-            />
-          </div>
-        </Form.Group>
-        <Form.Group className="mb-3" controlId="formProviderExample">
-          <Form.Label>PID Example:</Form.Label>
-          <Form.Control
-            type="text"
-            placeholder="Provide a valid PID as an example"
-            onChange={(e) => setInfo({ ...info, example: e.target.value })}
-            value={info.example}
-          />
-        </Form.Group>
-        <Button onClick={handleSubmit}>Submit</Button>{" "}
-        <Link className="btn btn-secondary ms-2" to="/supported-pids">
-          Cancel
+          </Form.Group>
+        </fieldset>
+        {editMode !== 2 && (
+          <>
+            <Button onClick={handleSubmit}>Submit</Button>{" "}
+          </>
+        )}
+        <Link className="btn btn-secondary ms-2" to="/managed-pids">
+          {editMode === 2 ? "Back" : "Cancel"}
         </Link>
       </Form>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider, KeycloakLogout, ProtectedRoute } from "./auth";
 import Navigation from "./Navigation";
 import AddEditProvider from "./AddEditProvider";
 import SupportedPids from "./SupportedPids";
+import ManagedPids from "./ManagedPids";
 import { Toaster } from "react-hot-toast";
 import { Footer } from "./Footer";
 
@@ -24,7 +25,7 @@ const DEBOUNCE_TIMEOUT = 300;
 
 // backend call to identify provider types
 
-// resolution mode valus
+// resolution mode values
 enum ResolutionModes {
   LandingPage = "landingpage",
   Metadata = "metadata",
@@ -275,19 +276,36 @@ function App() {
             <Route path="/" element={<Main />} />
             <Route path="/supported-pids" element={<SupportedPids />} />
             <Route
-              path="/supported-pids/add"
-              element={<ProtectedRoute adminMode={true} />}
+              path="/managed-pids"
+              element={
+                <ProtectedRoute routeRoles={["provider_admin", "admin"]} />
+              }
+            >
+              <Route index element={<ManagedPids />} />
+            </Route>
+            <Route
+              path="/managed-pids/add"
+              element={
+                <ProtectedRoute routeRoles={["provider_admin", "admin"]} />
+              }
             >
               <Route index element={<AddEditProvider />} />
             </Route>
             <Route
-              path="/supported-pids/edit/:id"
-              element={<ProtectedRoute adminMode={true} />}
+              path="/managed-pids/view/:id"
+              element={
+                <ProtectedRoute routeRoles={["provider_admin", "admin"]} />
+              }
             >
-              <Route index element={<AddEditProvider editMode={true} />} />
+              <Route index element={<AddEditProvider editMode={2} />} />
             </Route>
-            <Route path="/login" element={<ProtectedRoute adminMode={false} />}>
-              <Route index element={<SupportedPids />} />
+            <Route
+              path="/managed-pids/edit/:id"
+              element={
+                <ProtectedRoute routeRoles={["admin", "provider_admin"]} />
+              }
+            >
+              <Route index element={<AddEditProvider editMode={1} />} />
             </Route>
             <Route path="/logout" element={<KeycloakLogout />} />
           </Routes>

--- a/src/ManagedPids.tsx
+++ b/src/ManagedPids.tsx
@@ -1,0 +1,508 @@
+import { useState, useEffect, useContext } from "react";
+import { useSearchParams, useNavigate, Link } from "react-router-dom";
+import { AuthContext } from "./auth";
+import {
+  FaCheck,
+  FaCog,
+  FaEdit,
+  FaExclamationTriangle,
+  FaIdCard,
+  FaInfoCircle,
+  FaPlusCircle,
+  FaTrashAlt,
+  FaUser,
+} from "react-icons/fa";
+import { ApiResponse, Provider } from "./types";
+import { DeleteModal } from "./DeleteModal";
+import { Alert, Button } from "react-bootstrap";
+import toast from "react-hot-toast";
+import { StatusModal } from "./StatusModal";
+
+// API endpoint declared in env variable
+const PIDMR_API = import.meta.env.VITE_PIDMR_API;
+const PROVIDERS_ADMIN_API_ROUTE = `${PIDMR_API}/v1/admin/providers`;
+
+interface DeleteModalConfig {
+  show: boolean;
+  title: string;
+  message: string;
+  itemId: string;
+  itemName: string;
+}
+
+interface StatusModalConfig {
+  show: boolean;
+  itemId: string;
+  itemName: string;
+  status: string;
+}
+
+// Component to render a simple info page about Managed PIDs
+function ManagedPids() {
+  const { roles, userid } = useContext(AuthContext)!;
+  const admin = roles.includes("admin");
+  const providerAdmin = roles.includes("provider_admin");
+
+  // provider data from backend
+  const [data, setData] = useState<ApiResponse | null>(null);
+  // small trigger to refetch data when deleting items
+  const [triggerFetch, setTriggerFetch] = useState(true);
+  // router urlparams for pagination
+  const [searchParams] = useSearchParams();
+  // navigate to change on pagination
+  const navigate = useNavigate();
+
+  const { keycloak } = useContext(AuthContext)!;
+
+  const [deleteModalConfig, setDeleteModalConfig] = useState<DeleteModalConfig>(
+    {
+      show: false,
+      title: "Delete PID Provider",
+      message: "Are you sure you want to delete the following PID Provider?",
+      itemId: "",
+      itemName: "",
+    },
+  );
+
+  const [statusModalConfig, setStatusModalConfig] = useState<StatusModalConfig>(
+    {
+      show: false,
+      status: "",
+      itemId: "",
+      itemName: "",
+    },
+  );
+
+  const handleDeleteOpenModal = (item: Provider) => {
+    setDeleteModalConfig({
+      ...deleteModalConfig,
+      show: true,
+      itemId: item.id.toString(),
+      itemName: item.name,
+    });
+  };
+
+  const handleApproveOpenModal = (item: Provider) => {
+    setStatusModalConfig({
+      ...statusModalConfig,
+      show: true,
+      status: item.status || "",
+      itemId: item.id.toString(),
+      itemName: item.name,
+    });
+  };
+
+  const handleStatusConfirmed = async (id: string, status: string) => {
+    if (keycloak) {
+      const url = PROVIDERS_ADMIN_API_ROUTE + "/" + id + "/update-status";
+      try {
+        const response = await fetch(url, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${keycloak.token}`,
+          },
+          body: JSON.stringify({ status: status }),
+        });
+
+        if (response.ok) {
+          setStatusModalConfig({
+            ...statusModalConfig,
+            show: false,
+            status: "",
+            itemId: "",
+            itemName: "",
+          });
+          // refresh data
+          toast.success("Provider status changed!");
+          setTriggerFetch(true);
+        } else {
+          response.json().then((data) => {
+            toast.error(
+              <div>
+                <strong>{`Error trying to change status for Provider:`}</strong>
+                <br />
+                <span>{data.message}</span>
+              </div>,
+            );
+          });
+        }
+      } catch (error: unknown) {
+        console.error("Error:", error);
+      }
+    }
+  };
+
+  const handleDeleteConfirmed = async (id: string) => {
+    if (keycloak) {
+      const url = PROVIDERS_ADMIN_API_ROUTE + "/" + id;
+      try {
+        const response = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${keycloak.token}`,
+          },
+        });
+
+        if (response.ok) {
+          setDeleteModalConfig({
+            ...deleteModalConfig,
+            show: false,
+            itemId: "",
+            itemName: "",
+          });
+          // refresh data
+          toast.success("Provider deleted!");
+          setTriggerFetch(true);
+        } else {
+          response.json().then((data) => {
+            toast.error(
+              <div>
+                <strong>{`Error trying to delete Provider:`}</strong>
+                <br />
+                <span>{data.message}</span>
+              </div>,
+            );
+          });
+        }
+      } catch (error: unknown) {
+        console.error("Error:", error);
+      }
+    }
+  };
+
+  function handleChangeSize(evt: { target: { value: string } }) {
+    // navigate to the same page but with new url parameter for size and go to first page
+    navigate("./?size=" + evt.target.value + "&page=1");
+  }
+
+  useEffect(() => {
+    // parse the page & size url params
+    let page = parseInt(searchParams.get("page") || "");
+    let size = parseInt(searchParams.get("size") || "");
+
+    // if no page given assume first
+    if (!page) {
+      page = 1;
+    }
+
+    // if no size given or size too big assume 20 and start at first page
+    if (!size || size > 100) {
+      size = 20;
+      page = 1;
+    }
+
+    // fetch the data from the api
+    const fetchData = async () => {
+      if (keycloak) {
+        try {
+          const response = await fetch(
+            PROVIDERS_ADMIN_API_ROUTE + "?size=" + size + "&page=" + page,
+            {
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${keycloak.token}`,
+              },
+            },
+          );
+          const json = await response.json();
+          setData(json);
+        } catch (error) {
+          console.log(error);
+        }
+      }
+    };
+    fetchData();
+    setTriggerFetch(false);
+  }, [searchParams, triggerFetch, keycloak]);
+
+  // prepare the list of supported providers
+  const providers: React.ReactNode[] = [];
+
+  // prep the page navigation element
+  let pageNav = null;
+  // prep the element that holds the page next, prev controls
+  let pageFlip = null;
+
+  const pageSize = parseInt(searchParams.get("size") || "");
+
+  // if data is fetched and content exists do
+  if (data && data.content) {
+    // for each provider in data prepare its view
+    for (const item of data.content) {
+      // prep the supported modes element for the provider
+      const actions = [];
+      for (const actionItem of item.resolution_modes) {
+        actions.push(
+          <span
+            className="badge badge-small bg-secondary mx-1"
+            key={actionItem.mode}
+          >
+            {actionItem.name}
+          </span>,
+        );
+      }
+      // push to the provider list the element view of a provider
+      // the provider is rendered as a card with
+      // provider name and prefix in the card-header
+      // provider description in the card-body
+      // provider supported modes in the card-footer
+
+      const disableControls =
+        !admin && providerAdmin && item.status === "APPROVED";
+
+      providers.push(
+        <li key={item.type} className="m-4">
+          <div
+            className="card"
+            style={{
+              border: "1px dashed black",
+              backgroundColor:
+                item.status && item.status === "PENDING" ? "#fff7e0" : "",
+            }}
+          >
+            <div className="card-header">
+              <div className="d-flex justify-content-between">
+                <div>
+                  <span
+                    style={{ color: "black", border: "1px black solid" }}
+                    className="badge badge-small bg-warning"
+                  >
+                    {item.type}
+                  </span>
+                  <strong style={{ marginLeft: "0.6rem" }}>{item.name}</strong>
+                </div>
+                {(admin || providerAdmin) && (
+                  <div>
+                    <Button
+                      className="me-2 mb-1 border-black"
+                      size="sm"
+                      variant={
+                        item.status === "APPROVED" ? "success" : "warning"
+                      }
+                      onClick={() => {
+                        handleApproveOpenModal(item);
+                      }}
+                      disabled={providerAdmin}
+                    >
+                      {item.status && item.status === "APPROVED" ? (
+                        <FaCheck />
+                      ) : (
+                        <FaCog />
+                      )}{" "}
+                      {item.status}
+                    </Button>
+                    <Link
+                      to={`/managed-pids/view/${item.id}`}
+                      className="btn me-2 btn-sm mb-1 btn-outline-dark"
+                    >
+                      <FaInfoCircle /> Details
+                    </Link>
+                    {!disableControls ? (
+                      <Link
+                        to={`/managed-pids/edit/${item.id}`}
+                        className="btn btn-sm mb-1 btn-outline-dark"
+                      >
+                        <FaEdit /> Edit
+                      </Link>
+                    ) : (
+                      <span className="btn btn-sm mb-1 btn-outline-dark disabled">
+                        <FaEdit /> Edit
+                      </span>
+                    )}
+                    <Button
+                      className="ms-2 mb-1"
+                      size="sm"
+                      variant="outline-danger"
+                      onClick={() => {
+                        handleDeleteOpenModal(item);
+                      }}
+                      disabled={disableControls}
+                    >
+                      <FaTrashAlt /> Delete
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="card-body">{item.description}</div>
+            {actions.length > 0 && (
+              <div className="card-footer">
+                <div
+                  className={`d-flex ${
+                    admin && item.user_id
+                      ? "justify-content-between"
+                      : "justify-content-end"
+                  }`}
+                >
+                  {admin && item.user_id && (
+                    <div>
+                      <small className="text-secondary me-2">
+                        created by:{" "}
+                      </small>
+                      <strong className="badge bg-secondary">
+                        <FaUser className="me-1" />
+                        {userid}
+                      </strong>
+                    </div>
+                  )}
+                  <div>
+                    <small className="text-secondary mx-2">modes:</small>
+                    {actions}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </li>,
+      );
+    }
+
+    // if links exist render the page flip element
+    if (data.links && data.links.length > 0) {
+      const start = (data.number_of_page - 1) * pageSize;
+      const end = start + data.content.length;
+
+      pageFlip = (
+        <div className="d-flex justify-content-between">
+          <div>
+            {start > 0 && (
+              <>
+                <Link
+                  className="btn btn-primary btn-sm mx-2"
+                  to={"./?size=" + pageSize + "&page=1"}
+                >
+                  First
+                </Link>
+                <Link
+                  className="btn  btn-primary btn-sm mx-2"
+                  to={
+                    "./?size=" + pageSize + "&page=" + (data.number_of_page - 1)
+                  }
+                >
+                  ← Prev
+                </Link>
+              </>
+            )}
+            <span className="mx-4">
+              <strong>{start + 1}</strong> to <strong>{end}</strong> out of{" "}
+              <strong>{data.total_elements}</strong>
+            </span>
+            {end < data.total_elements && (
+              <>
+                <Link
+                  to={
+                    "./?size=" + pageSize + "&page=" + (data.number_of_page + 1)
+                  }
+                  className="btn  btn-primary btn-sm mx-2"
+                >
+                  Next →
+                </Link>
+                <Link
+                  to={"./?size=" + pageSize + "&page=" + data.total_pages}
+                  className="btn  btn-primary btn-sm mx-2"
+                >
+                  Last
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // here render the page navigation footer
+    pageNav = (
+      <div className="d-flex justify-content-between">
+        <DeleteModal
+          show={deleteModalConfig.show}
+          title={deleteModalConfig.title}
+          message={deleteModalConfig.message}
+          itemId={deleteModalConfig.itemId}
+          itemName={deleteModalConfig.itemName}
+          onHide={() => {
+            setDeleteModalConfig({ ...deleteModalConfig, show: false });
+          }}
+          onDelete={() => {
+            handleDeleteConfirmed(deleteModalConfig.itemId);
+          }}
+        />
+        <StatusModal
+          show={statusModalConfig.show}
+          itemId={statusModalConfig.itemId}
+          itemName={statusModalConfig.itemName}
+          status={statusModalConfig.status}
+          onHide={() => {
+            setStatusModalConfig({ ...statusModalConfig, show: false });
+          }}
+          onAction={() => {
+            if (statusModalConfig.status === "APPROVED") {
+              handleStatusConfirmed(statusModalConfig.itemId, "PENDING");
+            } else {
+              handleStatusConfirmed(statusModalConfig.itemId, "APPROVED");
+            }
+          }}
+        />
+
+        {/* This is the optional element to flip between pages */}
+        {pageFlip}
+        {/* This is the element to select page size */}
+        <div>
+          <span className="mx-1">results per page: </span>
+          <select
+            name="per-page"
+            value={searchParams.get("size") || "20"}
+            id="per-page"
+            onChange={handleChangeSize}
+          >
+            <option value="5">5</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+          </select>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Alert variant="success" className="mt-2">
+        <FaIdCard size="1.6rem" className="me-2" /> You have logged in as{" "}
+        <strong>{userid}</strong> having the{" "}
+        {roles.length > 1 ? "roles" : "role"} of:{" "}
+        <strong>{roles.join(", ")}</strong>
+      </Alert>
+      <div className="my-2">
+        <div className="d-flex justify-content-between">
+          <div>
+            <h5>Managed Pids:</h5>
+          </div>
+          {(admin || providerAdmin) && (
+            <div>
+              <Link className="btn-outline-dark btn" to="/managed-pids/add">
+                <FaPlusCircle /> Add new PID provider
+              </Link>
+            </div>
+          )}
+        </div>
+        {providers.length ? (
+          <ul className="list-unstyled">{providers}</ul>
+        ) : (
+          <Alert variant="warning" className="mt-4 text-center">
+            <FaExclamationTriangle size="1.8rem" />
+            <br />
+            No PID Provider entries found.
+            <br />
+            Please create a <Link to="/managed-pids/add">new one...</Link>
+          </Alert>
+        )}
+        <hr />
+        {pageNav}
+      </div>
+    </>
+  );
+}
+
+export default ManagedPids;

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import logo from "./assets/logo.svg";
 import { AuthContext } from "./auth";
 import { useContext } from "react";
-import { FaUser } from "react-icons/fa";
+import { FaCog, FaSignOutAlt, FaUser } from "react-icons/fa";
 
 function Navigation() {
   const { authenticated, userid } = useContext(AuthContext)!;
@@ -46,7 +46,7 @@ function Navigation() {
         </Nav>
         {/* login button */}
         {!authenticated && (
-          <Link to="/login" className="btn btn-primary my-2">
+          <Link to="/managed-pids" className="btn btn-primary my-2">
             Login
           </Link>
         )}
@@ -58,8 +58,13 @@ function Navigation() {
               </Dropdown.Toggle>
 
               <Dropdown.Menu>
+                <Dropdown.Item as={Link} to="/managed-pids">
+                  <FaCog className="me-2" />
+                  Manage PIDs
+                </Dropdown.Item>
+                <hr />
                 <Dropdown.Item as={Link} to="/logout">
-                  Logout
+                  <FaSignOutAlt className="me-2" /> Logout
                 </Dropdown.Item>
               </Dropdown.Menu>
             </Dropdown>

--- a/src/StatusModal.tsx
+++ b/src/StatusModal.tsx
@@ -1,0 +1,102 @@
+import { Modal, Button, ListGroup, ListGroupItem } from "react-bootstrap";
+import { FaCheck, FaCog } from "react-icons/fa";
+
+interface StatusModalProps {
+  itemId: string;
+  itemName: string;
+  status: string;
+  show: boolean;
+  onHide: () => void;
+  onAction: () => void;
+}
+/**
+ * Implements a simple component that displays a modal (popup window) when
+ * the user needs to confirm the approval/disproval of an item. Modal accepts a list of
+ * properties such as a title, message, itemId and itemName.
+ * Also it accepts two callback functions: onHide (what to do when modal closes)
+ * and onAction (what to do when user clicks Confirm button)
+ */
+export function StatusModal(props: StatusModalProps) {
+  let mode = 0;
+  if (props.status === "APPROVED") {
+    mode = 1;
+  }
+
+  return (
+    <Modal
+      show={props.show}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+      onHide={props.onHide}
+    >
+      <Modal.Header
+        className={`${mode ? "bg-warning" : "bg-success"} text-white`}
+        closeButton
+      >
+        <Modal.Title id="contained-modal-title-vcenter">
+          {mode ? (
+            <span>
+              <FaCog className="me-2" />
+              Change status to "Pending"
+            </span>
+          ) : (
+            <span>
+              <FaCheck className="me-2" />
+              Change status to "Approved"
+            </span>
+          )}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {mode ? (
+          <span>
+            Change item status from:{" "}
+            <span className="badge bg-success">
+              <FaCheck /> Approved
+            </span>{" "}
+            →{" "}
+            <span className="badge bg-warning">
+              <FaCog /> Pending
+            </span>{" "}
+            ?
+          </span>
+        ) : (
+          <span>
+            Change item status from:{" "}
+            <span className="badge bg-warning">
+              <FaCog /> Pending
+            </span>{" "}
+            →{" "}
+            <span className="badge bg-success">
+              <FaCheck /> Approved
+            </span>{" "}
+            ?
+          </span>
+        )}
+
+        <ListGroup className="mt-2">
+          <ListGroupItem>
+            <strong>Name: </strong>
+            {props.itemName}
+          </ListGroupItem>
+          <ListGroupItem>
+            <strong>ID: </strong>
+            {props.itemId}
+          </ListGroupItem>
+        </ListGroup>
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button
+          className={`${mode ? "btn-warning" : "btn-success"} me-4`}
+          onClick={props.onAction}
+        >
+          Confirm
+        </Button>
+        <Button className="btn-secondary" onClick={props.onHide}>
+          Cancel
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -4,8 +4,8 @@ import Keycloak from "keycloak-js";
 interface AuthContextProps {
   authenticated: boolean;
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
-  admin: boolean;
-  setAdmin: React.Dispatch<React.SetStateAction<boolean>>;
+  roles: string[];
+  setRoles: React.Dispatch<React.SetStateAction<string[]>>;
   userid: string;
   setUserid: React.Dispatch<React.SetStateAction<string>>;
   keycloak: NullableKeycloak; // Replace 'any' with the appropriate type for your keycloak object
@@ -21,7 +21,7 @@ type NullableKeycloak = null | Keycloak;
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authenticated, setAuthenticated] = useState(false);
   const [userid, setUserid] = useState("");
-  const [admin, setAdmin] = useState(false);
+  const [roles, setRoles] = useState<string[]>([]);
   const [keycloak, setKeycloak] = useState<NullableKeycloak>(null);
 
   const authContextValue: AuthContextProps = {
@@ -29,8 +29,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setAuthenticated,
     userid,
     setUserid,
-    admin,
-    setAdmin,
+    roles,
+    setRoles,
     keycloak,
     setKeycloak,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ export type ApiResponse = {
   links: ApiResponseLink[];
 };
 
+export type ProfileResponse = {
+  id: string;
+  roles: string[];
+};
+
 export type ApiResponseLink = {
   href: string;
   rel: string;
@@ -20,7 +25,9 @@ export type Provider = {
   description: string;
   resolution_modes: ResolutionMode[];
   regexes: string[];
+  status?: string;
   example?: string;
+  user_id: string | null;
 };
 
 export type ResolutionMode = {


### PR DESCRIPTION
# 🎯 Goal
Give the ability for an admin or a provider admin to manage new pid provider entries. A provider admin can only add a new entry and wait until it is approved. Admin can add/edit/delete and also approve entries or return them to pending status

# 🏗️ Implementation
- [x] Remove add / edit / delete buttons from supported pids view. This view now becomes read only
- [x] Create a new managed pids view that allows admins and provider admins to manage pid entries. This view calls the `/admin/providers` api path in order to display available pid provider entries. An admin will see all available entries. A provider admin will see only the entries that has created. 
- [x] Add StatusModal component to be able to change status of a pid provider entry from Approved to Pending and vice versa
- [x] Change Auth methods to call `/users/profile` in order to grab user id and user roles 
- [x] Update the AddEdit Component with a new mode that allows to view the provider details by disabling the form fields
- [x] Configure routes and navigation items for the new views
- [x] Login now leads to the managed pids view. 
- [x] A user without any role assigned (admin, provider_admin) automatically logs out 