### PR TITLE
PIDMR-168 Allow protected routes with no required roles

### DIFF
--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -9,6 +9,8 @@ const PIDMR_API = import.meta.env.VITE_PIDMR_API;
 const PROFILE_API_ROUTE = `${PIDMR_API}/v1/users/profile`;
 
 function roleMatch(roles: string[], routeRoles: string[]) {
+  // if route has no required roles defined -> return always true
+  if (!routeRoles.length) return true;
   return roles.some((roleItem) => routeRoles.includes(roleItem));
 }
 


### PR DESCRIPTION
This will allow protected routes (accessed only under a valid login) that don't require a special role 

Declare the protected route in App.tsx with empty table such as 
```
<ProtectedRoute routeRoles={[]} />
```